### PR TITLE
Cache the .stack folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 
 cache:
   directories:
+    - $HOME/.stack
     - .stack-work
 
 matrix:


### PR DESCRIPTION
Installed packages and GHC are stored there, so not caching it means
rebuilding all dependencies every time.